### PR TITLE
updated min version of php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": ">=5.5.0",
+        "php": ">=5.6.4",
         "illuminate/database": "~5.3",
         "illuminate/support": "~5.3",
         "laravel/passport": ">=0.2.2"


### PR DESCRIPTION
updated min version of php as illuminate/support 5.3 requires php >= 5.6.4