### PR TITLE
Remove expired tokens generated by client_grant

### DIFF
--- a/src/Console/Commands/Purge.php
+++ b/src/Console/Commands/Purge.php
@@ -42,6 +42,11 @@ class Purge extends Command
                 ->where('expires_at', '<', (new DateTime())->setTimestamp(time() - $difference))
                 ->delete();
         }
+        
+        $count += DB::table('oauth_access_tokens')
+            ->where('expires_at', '<', new DateTime())
+            ->where('user_id', '=', null)
+            ->delete();
 
         $this->info('Successfully deleted expired tokens: ' . $count);
     }


### PR DESCRIPTION
This commit remove all expired tokens generated by client_grant related in issue #44