### PR TITLE
Router patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A simple service provider that makes Laravel Passport work with Lumen
 ## Dependencies
 
 * PHP >= 5.6.3
-* Lumen >= 5.3
+* Lumen >= 5.5
 
 ## Installation via Composer
 

--- a/README.md
+++ b/README.md
@@ -124,13 +124,13 @@ return [
 Next, you should call the LumenPassport::routes method within the boot method of your application. This method will register the routes necessary to issue access tokens and revoke access tokens, clients, and personal access tokens:
 
 ```php
-Dusterio\LumenPassport\LumenPassport::routes($app);
+Dusterio\LumenPassport\LumenPassport::routes($app->router);
 ```
 
 You can add that into an existing group, or add use this route registrar independently like so;
 
 ```php
-Dusterio\LumenPassport\LumenPassport::routes($app, ['prefix' => 'v1/oauth']);
+Dusterio\LumenPassport\LumenPassport::routes($app->router, null, ['prefix' => 'v1/oauth']);
 ```
 
 ## User model

--- a/README.md
+++ b/README.md
@@ -124,13 +124,13 @@ return [
 Next, you should call the LumenPassport::routes method within the boot method of your application. This method will register the routes necessary to issue access tokens and revoke access tokens, clients, and personal access tokens:
 
 ```php
-Dusterio\LumenPassport\LumenPassport::routes($app->router);
+Dusterio\LumenPassport\LumenPassport::routes();
 ```
 
 You can add that into an existing group, or add use this route registrar independently like so;
 
 ```php
-Dusterio\LumenPassport\LumenPassport::routes($app->router, null, ['prefix' => 'v1/oauth']);
+Dusterio\LumenPassport\LumenPassport::routes(null, ['prefix' => 'v1/oauth']);
 ```
 
 ## User model

--- a/src/LumenPassport.php
+++ b/src/LumenPassport.php
@@ -64,10 +64,12 @@ class LumenPassport
     /**
      * Get a Passport route registrar.
      *
-     * @param  array  $options
+     * @param  \Laravel\Lumen\Routing\Router $router
+     * @param  callable|null                 $callback
+     * @param  array                         $options
      * @return RouteRegistrar
      */
-    public static function routes($callback = null, array $options = [])
+    public static function routes($router, $callback = null, array $options = [])
     {
         $callback = $callback ?: function ($router) {
             $router->all();
@@ -80,9 +82,8 @@ class LumenPassport
 
         $options = array_merge($defaultOptions, $options);
 
-        $callback->group($options, function ($router) use ($callback) {
-            $routes = new RouteRegistrar($router);
-            $routes->all();
+        $router->group($options, function ($router) use ($callback) {
+            $callback(new RouteRegistrar($router));
         });
     }
 }

--- a/src/LumenPassport.php
+++ b/src/LumenPassport.php
@@ -6,6 +6,7 @@ use Laravel\Passport\Passport;
 use DateTimeInterface;
 use DateInterval;
 use Carbon\Carbon;
+use Illuminate\Support\Facades\Route;
 
 class LumenPassport
 {
@@ -64,12 +65,11 @@ class LumenPassport
     /**
      * Get a Passport route registrar.
      *
-     * @param  \Laravel\Lumen\Routing\Router $router
      * @param  callable|null                 $callback
      * @param  array                         $options
      * @return RouteRegistrar
      */
-    public static function routes($router, $callback = null, array $options = [])
+    public static function routes($callback = null, array $options = [])
     {
         $callback = $callback ?: function ($router) {
             $router->all();
@@ -82,7 +82,7 @@ class LumenPassport
 
         $options = array_merge($defaultOptions, $options);
 
-        $router->group($options, function ($router) use ($callback) {
+        Route::group($options, function ($router) use ($callback) {
             $callback(new RouteRegistrar($router));
         });
     }

--- a/src/RouteRegistrar.php
+++ b/src/RouteRegistrar.php
@@ -5,19 +5,19 @@ namespace Dusterio\LumenPassport;
 class RouteRegistrar
 {
     /**
-     * Application
+     * \Laravel\Lumen\Routing\Router Router
      */
-    private $app;
+    private $router;
 
     /**
      * Create a new route registrar instance.
      *
-     * @param  $app
+     * @param  \Laravel\Lumen\Routing\Router $router
      * @return void
      */
-    public function __construct($app)
+    public function __construct(\Laravel\Lumen\Routing\Router $router)
     {
-        $this->app = $app;
+        $this->router = $router;
     }
 
     /**
@@ -40,18 +40,18 @@ class RouteRegistrar
      */
     public function forAccessTokens()
     {
-        $this->app->post('/token', [
+        $this->router->post('/token', [
             'uses' => 'AccessTokenController@issueToken',
             'namespace' => '\Dusterio\LumenPassport\Http\Controllers'
         ]);
 
-        $this->app->group(['middleware' => ['auth']], function () {
-            $this->app->get('/tokens', [
+        $this->router->group(['middleware' => ['auth']], function () {
+            $this->router->get('/tokens', [
                 'uses' => 'AuthorizedAccessTokenController@forUser',
                 'namespace' => '\Laravel\Passport\Http\Controllers'
             ]);
 
-            $this->app->delete('/tokens/{token_id}', [
+            $this->router->delete('/tokens/{token_id}', [
                 'uses' => 'AuthorizedAccessTokenController@destroy',
                 'namespace' => '\Laravel\Passport\Http\Controllers'
             ]);
@@ -65,7 +65,7 @@ class RouteRegistrar
      */
     public function forTransientTokens()
     {
-        $this->app->post('/token/refresh', [
+        $this->router->post('/token/refresh', [
             'middleware' => ['auth'],
             'uses' => 'TransientTokenController@refresh',
             'namespace' => '\Laravel\Passport\Http\Controllers'
@@ -79,23 +79,23 @@ class RouteRegistrar
      */
     public function forClients()
     {
-        $this->app->group(['middleware' => ['auth']], function () {
-            $this->app->get('/clients', [
+        $this->router->group(['middleware' => ['auth']], function () {
+            $this->router->get('/clients', [
                 'uses' => 'ClientController@forUser',
                 'namespace' => '\Laravel\Passport\Http\Controllers'
             ]);
 
-            $this->app->post('/clients', [
+            $this->router->post('/clients', [
                 'uses' => 'ClientController@store',
                 'namespace' => '\Laravel\Passport\Http\Controllers'
             ]);
 
-            $this->app->put('/clients/{client_id}', [
+            $this->router->put('/clients/{client_id}', [
                 'uses' => 'ClientController@update',
                 'namespace' => '\Laravel\Passport\Http\Controllers'
             ]);
 
-            $this->app->delete('/clients/{client_id}', [
+            $this->router->delete('/clients/{client_id}', [
                 'uses' => 'ClientController@destroy',
                 'namespace' => '\Laravel\Passport\Http\Controllers'
             ]);
@@ -109,23 +109,23 @@ class RouteRegistrar
      */
     public function forPersonalAccessTokens()
     {
-        $this->app->group(['middleware' => ['auth']], function () {
-            $this->app->get('/scopes', [
+        $this->router->group(['middleware' => ['auth']], function () {
+            $this->router->get('/scopes', [
                 'uses' => 'ScopeController@all',
                 'namespace' => '\Laravel\Passport\Http\Controllers'
             ]);
 
-            $this->app->get('/personal-access-tokens', [
+            $this->router->get('/personal-access-tokens', [
                 'uses' => 'PersonalAccessTokenController@forUser',
                 'namespace' => '\Laravel\Passport\Http\Controllers'
             ]);
 
-            $this->app->post('/personal-access-tokens', [
+            $this->router->post('/personal-access-tokens', [
                 'uses' => 'PersonalAccessTokenController@store',
                 'namespace' => '\Laravel\Passport\Http\Controllers'
             ]);
 
-            $this->app->delete('/personal-access-tokens/{token_id}', [
+            $this->router->delete('/personal-access-tokens/{token_id}', [
                 'uses' => 'PersonalAccessTokenController@destroy',
                 'namespace' => '\Laravel\Passport\Http\Controllers'
             ]);


### PR DESCRIPTION
**Note** This is a breaking change for Lumen versions `<5.5`.

When calling `LumenPassport::routes` you now have to pass `$app->router` (\Laravel\Lumen\Routing\Router). This is due to the Lumen 5.5 PSR-11 changes. See [Upgrading To 5.5.0 From 5.4](https://lumen.laravel.com/docs/5.5/upgrade#upgrade-5.5.0)

`LumenPassport::routes` has also been changed so you can actually pass a callback to it if needed.

**Update:**

Now that Lumen supports the [`Route`](https://github.com/laravel/lumen-framework/pull/656) facade we can simplify the `LumenPassport::routes` method and bring it inline with the [Passport library](https://github.com/laravel/passport/blob/0542f1f82edfbf857d0197c34a3d41f549aff30a/src/Passport.php#L104).