### PR TITLE
Updated README Registering Routes example

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,13 +131,13 @@ Next, you should call the LumenPassport::routes method within the boot method of
 This method will register the routes necessary to issue access tokens and revoke access tokens, clients, and personal access tokens:
 
 ```php
-Dusterio\LumenPassport\LumenPassport::routes($this->app);
+\Dusterio\LumenPassport\LumenPassport::routes($this->app);
 ```
 
 You can add that into an existing group, or add use this route registrar independently like so;
 
 ```php
-Dusterio\LumenPassport\LumenPassport::routes($this->app, ['prefix' => 'v1/oauth']);
+\Dusterio\LumenPassport\LumenPassport::routes($this->app, ['prefix' => 'v1/oauth']);
 ```
 
 ## User model


### PR DESCRIPTION
Updated example with a backslash in front of call to the routes method, as it won't call the correct method otherwise.

Like so: \Dusterio\LumenPassport\LumenPassport::routes()