### PR TITLE
Fixing regex bug where the app would break on Lumen 5.7.x

### DIFF
--- a/src/LumenPassport.php
+++ b/src/LumenPassport.php
@@ -72,7 +72,7 @@ class LumenPassport
      */
     public static function routes($callback = null, array $options = [])
     {
-        if ($callback instanceof Application && preg_match('/5\.[56]\..*/', $callback->version())) $callback = $callback->router;
+        if ($callback instanceof Application && preg_match('/5\.[5-7]\..*/', $callback->version())) $callback = $callback->router;
 
         $callback = $callback ?: function ($router) {
             $router->all();


### PR DESCRIPTION
The regex in LumenPassport::routes will break the app in Lumen 5.7. This will fix that. 