### PR TITLE
Remove direct access to models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-vendor/
-.idea/
+/vendor
+/.idea
+/composer.lock

--- a/src/Http/Controllers/AccessTokenController.php
+++ b/src/Http/Controllers/AccessTokenController.php
@@ -44,9 +44,7 @@ class AccessTokenController extends \Laravel\Passport\Http\Controllers\AccessTok
             $tokenId = $this->jwt->parse($payload['access_token'])->getClaim('jti');
             $token = $this->tokens->find($tokenId);
 
-            if ($token->client->firstParty() && LumenPassport::$allowMultipleTokens) {
-                // We keep previous tokens for password clients
-            } else {
+            if (!$token->client->firstParty() || !LumenPassport::$allowMultipleTokens) {
                 $this->revokeOrDeleteAccessTokens($token, $tokenId);
             }
         }
@@ -80,7 +78,7 @@ class AccessTokenController extends \Laravel\Passport\Http\Controllers\AccessTok
      */
     protected function revokeOrDeleteAccessTokens(Token $token, $tokenId)
     {
-        $query = Token::where('user_id', $token->user_id)->where('client_id', $token->client_id);
+        $query = Passport::token()->where('user_id', $token->user_id)->where('client_id', $token->client_id);
 
         if ($tokenId) {
             $query->where('id', '<>', $tokenId);

--- a/src/PassportServiceProvider.php
+++ b/src/PassportServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Dusterio\LumenPassport;
 
 use Dusterio\LumenPassport\Console\Commands\Purge;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Database\Connection;
 
@@ -13,14 +14,12 @@ use Illuminate\Database\Connection;
 class PassportServiceProvider extends ServiceProvider
 {
     /**
-     * Bootstrap any application services.
-     *
      * @return void
      */
-    public function boot()
+    public function register()
     {
-        $this->app->singleton(Connection::class, function() {
-            return $this->app['db.connection'];
+        $this->app->singleton(Connection::class, function () {
+            return DB::connection(env('PASSPORT_CONNECTION', 'default'));
         });
 
         if (preg_match('/5\.[67]\.\d+/', $this->app->version())) {
@@ -35,10 +34,13 @@ class PassportServiceProvider extends ServiceProvider
             ]);
         }
     }
+
     /**
+     * Bootstrap any application services.
+     *
      * @return void
      */
-    public function register()
+    public function boot()
     {
     }
 }


### PR DESCRIPTION
AccessTokenController@revokeOrDeleteAccessTokens no longer access Token's model directly. It now uses [Passport::token()](https://laravel.com/docs/5.7/passport#configuration) instead.
I also have added the feature to what connection should be used for passport. You only need to set PASSPORT_CONNECTION in your .env file.

