### PR TITLE
Fix Composer memory limit in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ php:
   - '7.0'
 
 before_script:
-  - composer install --dev
+  - COMPOSER_MEMORY_LIMIT=-1 travis_retry composer install --prefer-dist --no-interaction
 
 script:
   - ./vendor/bin/phpunit


### PR DESCRIPTION
It fixes memory limit in Travis CI with PHP 5.6.