### PR TITLE
Fix a bug where the passport routing is incompatible to Lumen 7

### DIFF
--- a/src/LumenPassport.php
+++ b/src/LumenPassport.php
@@ -72,7 +72,7 @@ class LumenPassport
      */
     public static function routes($callback = null, array $options = [])
     {
-        if ($callback instanceof Application && preg_match('/(5\.[5-8]\..*)|(6\..*)/', $callback->version())) $callback = $callback->router;
+        if ($callback instanceof Application && preg_match('/(5\.[5-8]\..*)|(6\..*)|(7\..*)/', $callback->version())) $callback = $callback->router;
 
         $callback = $callback ?: function ($router) {
             $router->all();


### PR DESCRIPTION
Hi there!

I just tried to update my project to Lumen 7 with your latest version, but unfortunately there is still the bug, that it's not using the correct router group access, so I corrected it in a fork.

I tested it locally and it works just fine.