### PR TITLE
[FIX] Removing deprecated functionalities

### DIFF
--- a/src/Http/Controllers/AccessTokenController.php
+++ b/src/Http/Controllers/AccessTokenController.php
@@ -86,10 +86,6 @@ class AccessTokenController extends \Laravel\Passport\Http\Controllers\AccessTok
             $query->where('id', '<>', $tokenId);
         }
 
-        if (Passport::$pruneRevokedTokens) {
-            $query->delete();
-        } else {
-            $query->update(['revoked' => true]);
-        }
+        $query->update(['revoked' => true]);
     }
 }

--- a/src/LumenPassport.php
+++ b/src/LumenPassport.php
@@ -34,14 +34,6 @@ class LumenPassport
     }
 
     /**
-     * Delete older tokens or just mark them as revoked?
-     */
-    public static function prunePreviousTokens()
-    {
-        Passport::$pruneRevokedTokens = true;
-    }
-
-    /**
      * Get or set when access tokens expire.
      *
      * @param  \DateTimeInterface|null  $date


### PR DESCRIPTION
Passport 9 removed pruneRevokedTokens and prunePreviousTokens() causing errors when trying to use them [REF](https://github.com/laravel/passport/pull/1235/files)

It looks like those calls can be removed without any problem at all.