### PR TITLE
Support client UUIDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
 
 ## Extra features
 
-There are a couple of extra features that aren't present in Laravel Passport
+There are a couple of extra features that aren't present in Laravel Passport or need some manual adjustments in order to work.
 
 ### Allowing multiple tokens per client
 
@@ -203,6 +203,14 @@ If you don't specify client Id, it will simply fall back to Laravel Passport imp
 
 Simply run ```php artisan passport:purge``` to remove expired refresh tokens and their corresponding access tokens from the database.
 
+### Automatic configuration of client UUIDs (Laravel Passport 8.5 feature)
+
+In case you want to use UUIDs instead of numeric client IDs you might be interested in the native support introduced in [Laravel Passport 8.5](https://github.com/laravel/passport/pull/1231).
+In order to achieve this, please follow the following steps:
+* make sure you are using passport version `^8.5` and `ramsey/uuid` version `^4.0`
+* copy the default passport config into your Lumen config directory and set the `client_uuids` option to `true`
+* configure the new custom passport config in your `bootstrap/app.php`
+* manually apply the required database changes as listed in the `Laravel\Passport\Console\InstallCommand::configureUuids` method
 
 ## Running with Apache httpd
 

--- a/README.md
+++ b/README.md
@@ -203,11 +203,11 @@ If you don't specify client Id, it will simply fall back to Laravel Passport imp
 
 Simply run ```php artisan passport:purge``` to remove expired refresh tokens and their corresponding access tokens from the database.
 
-### Automatic configuration of client UUIDs (Laravel Passport 8.5 feature)
+### Client UUID support (Laravel Passport 8.5 feature)
 
 In case you want to use UUIDs instead of numeric client IDs you might be interested in the native support introduced in [Laravel Passport 8.5](https://github.com/laravel/passport/pull/1231).
 In order to achieve this, please follow the following steps:
-* make sure you are using passport version `^8.5` and `ramsey/uuid` version `^4.0`
+* make sure you are using passport version `>=8.5` and `ramsey/uuid` version `>=4.0`
 * copy the default passport config into your Lumen config directory and set the `client_uuids` option to `true`
 * configure the new custom passport config in your `bootstrap/app.php`
 * manually apply the required database changes as listed in the `Laravel\Passport\Console\InstallCommand::configureUuids` method

--- a/src/PassportServiceProvider.php
+++ b/src/PassportServiceProvider.php
@@ -3,8 +3,10 @@
 namespace Dusterio\LumenPassport;
 
 use Dusterio\LumenPassport\Console\Commands\Purge;
+use Illuminate\Contracts\Config\Repository;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Database\Connection;
+use Laravel\Passport\Passport;
 
 /**
  * Class CustomQueueServiceProvider
@@ -40,5 +42,8 @@ class PassportServiceProvider extends ServiceProvider
      */
     public function register()
     {
+        if ($this->app['config'] instanceof Repository && method_exists(Passport::class, 'setClientUuids')) {
+            Passport::setClientUuids($this->app['config']->get('passport.client_uuids', false));
+        }
     }
 }


### PR DESCRIPTION
Hi there,

Passport version `8.5` introduced the [support for client UUIDs](https://github.com/laravel/passport/pull/1231) instead of the default numeric IDs. I was interested to use this feature so I tried it in my Lumen app. Unfortunately, due to the nature of Lumen, the config flag to activate this option had to be manually activated in your service provider, because it ignores the manually configured Lumen config files in the original one.

In addition to that, there are some further adjustments one has to do in order to make it compatible with Lumen, so I adjusted the readme file.