### PR TITLE
Fix issue after using passport 10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
         "php": ">=5.6.4",
         "illuminate/database": "~5.3|~5.4|~5.5|~5.6|^6.0|^7.0|^8.0",
         "illuminate/support": "~5.3|~5.4|~5.5|~5.6|^6.0|^7.0|^8.0",
-        "laravel/passport": ">=0.2.2"
+        "laravel/passport": ">=0.2.2",
+        "zendframework/zend-diactoros": "^2.2"
     },
     "require-dev": {
         "fzaninotto/faker": "~1.4",


### PR DESCRIPTION
Class 'Zend\Diactoros\Response' not found {"exception":"[object] (Error(code: 0): Class 'Zend\\Diactoros\\Response' not found at /xxx/vendor/dusterio/lumen-passport/src/Http/Controllers/AccessTokenController.php:34)