### PR TITLE
Add compatibility for lcobucci/jwt 4.x

### DIFF
--- a/src/Http/Controllers/AccessTokenController.php
+++ b/src/Http/Controllers/AccessTokenController.php
@@ -48,7 +48,7 @@ class AccessTokenController extends \Laravel\Passport\Http\Controllers\AccessTok
             } else if (method_exists($token, 'claims')) {
                 $tokenId = $token->claims()->get('jti');
             } else {
-                throw new \RuntimeException('This package is not compatible to the used Laravel Passport version.');
+                throw new \RuntimeException('This package is not compatible with the Laravel Passport version used');
             }
 
             $token = $this->tokens->find($tokenId);


### PR DESCRIPTION
Fixes #148.
I added a deprecation notice for the `jwt` property. In future, the feature to support multiple tokens at once must be implemented deeper within the Passport integration to support it in `^11.0`.