### PR TITLE
Fix #154 - add compatibility to Passport 10.x

### DIFF
--- a/src/RouteRegistrar.php
+++ b/src/RouteRegistrar.php
@@ -63,7 +63,7 @@ class RouteRegistrar
 
         $this->app->group(['middleware' => ['auth']], function () {
             $this->app->get('/tokens', $this->prefix('AuthorizedAccessTokenController@forUser'));
-            $this->app->delete('/tokens/{token_id}', $this->prefix('AuthorizedAccessTokenController@destroy'));
+            $this->app->delete('/tokens/{tokenId}', $this->prefix('AuthorizedAccessTokenController@destroy'));
         });
     }
 
@@ -90,8 +90,8 @@ class RouteRegistrar
         $this->app->group(['middleware' => ['auth']], function () {
             $this->app->get('/clients', $this->prefix('ClientController@forUser'));
             $this->app->post('/clients', $this->prefix('ClientController@store'));
-            $this->app->put('/clients/{client_id}', $this->prefix('ClientController@update'));
-            $this->app->delete('/clients/{client_id}', $this->prefix('ClientController@destroy'));
+            $this->app->put('/clients/{clientId}', $this->prefix('ClientController@update'));
+            $this->app->delete('/clients/{clientId}', $this->prefix('ClientController@destroy'));
         });
     }
 


### PR DESCRIPTION
Sorry for the double PR, but I realized that in Passport 10, also the other methods require the camel-case syntax.