### PR TITLE
Docs to add config before installation. Fix #138

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ returns false.
 
 ### Migrate and install Laravel Passport
 
+Before installing Passport, make sure you have the [configuration](#configuration) file for auth in place.
+
 ```bash
 # Create new tables for Passport
 php artisan migrate


### PR DESCRIPTION
The `passport:install` command fails in case the project still doesn't have the proper auth config in place. This might not be an issue directly related to this package, but simply updating the installation instructions could help less experienced developers.

This issue was reported on #138.