### PR TITLE
docs: add use Laravel\Passport\HasApiTokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,9 @@ You can add that into an existing group, or add use this route registrar indepen
 Make sure your user model uses Passport's ```HasApiTokens``` trait, eg.:
 
 ```php
+//without the use it generates this error -> Call to undefined method App\Models\User::withAccessToken()
+use Laravel\Passport\HasApiTokens;
+
 class User extends Model implements AuthenticatableContract, AuthorizableContract
 {
     use HasApiTokens, Authenticatable, Authorizable;


### PR DESCRIPTION
//without the "use Laravel\Passport\HasApiTokens;" it generates this error -> Call to undefined method App\Models\User::withAccessToken() status 500
use Laravel\Passport\HasApiTokens;
![image](https://user-images.githubusercontent.com/21070792/147704068-b4338593-ef6f-490b-a321-4d497be3ac76.png)
